### PR TITLE
remove 'console.log(options)'

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -37,8 +37,6 @@ commander
 
 options     = commander.opts()
 
-console.log( options )
-
 splitArgs   = (strList) -> strList?.split(',') ? []
 
 


### PR DESCRIPTION
This removes the call to `console.log` that prints current options every time the cli is invoked. 